### PR TITLE
Force unwrap fromJson

### DIFF
--- a/snippets/builtValue.json
+++ b/snippets/builtValue.json
@@ -42,7 +42,7 @@
                 "\t}",
                 "",
                 "\tstatic ${1} fromJson(String jsonString) {",
-                "\t\treturn serializers.deserializeWith(${1}.serializer, json.decode(jsonString));",
+                "\t\treturn serializers.deserializeWith(${1}.serializer, json.decode(jsonString))!;",
                 "\t}",
                 "",
                 "\tstatic Serializer<${1}> get serializer => _\\$${1/(^[A-z]{1})/${1:/downcase}/}Serializer;",


### PR DESCRIPTION
Without the force unwrap, there is a return of invalid type error due to nullable type mismatch

<img width="743" alt="Screen Shot 2022-02-08 at 10 49 42 AM" src="https://user-images.githubusercontent.com/666539/153023757-3a10b121-82e8-4315-978a-86b1d2b03130.png">


With the force unwrap, the type is correct, and it will be a catchable runtime error if the JSON decode fails

<img width="562" alt="Screen Shot 2022-02-08 at 10 50 48 AM" src="https://user-images.githubusercontent.com/666539/153023964-11308803-f2d7-4ff1-a7c1-5dd0ebcb2332.png">

